### PR TITLE
"More self" / internals refactor

### DIFF
--- a/index.js
+++ b/index.js
@@ -139,6 +139,18 @@ swarm.classify = function() {
 // If any supported arguments have the `_self` value we resolve then first, and
 // then actually run the command.
 Step(function() {
+    // --filter.instanceId _self
+    if (argv.filter && argv.filter.instanceId == '_self') {
+        var next = this;
+        instanceMetadata.loadId(function(err, id) {
+            if (err) next(err);
+            argv.filter.instanceId = id;
+            next();
+        });
+    }
+    else { this() }
+}, function(err) {
+    if (err) throw err;
     // --filter.TAG _self
     var lookup = _(argv.filter).chain().map(function(v, k) {
         if (v == '_self') return k;
@@ -180,9 +192,7 @@ Step(function() {
             next();
         });
     }
-    else {
-        this();
-    }
+    else { this() }
 }, function(err) {
     if (err) throw err;
     swarm[command]();

--- a/index.js
+++ b/index.js
@@ -153,7 +153,9 @@ Step(function() {
         },
         function(err, tags) {
             if (err) throw (err);
-            argv.filter.Swarm = _(tags).pluck('Swarm').compact().first().value();
+            argv.filter.Swarm = _(tags).find(function(v){
+               return v.key == "Swarm";
+            }).value;
             next();
         });
     }
@@ -166,10 +168,11 @@ function(err) {
     // --regions _self
     var i = regions.indexOf('_self');
     if (i !== -1) {
+        var next = this;
         instanceMetadata.loadAz(function(err, az) {
-            if (err) this(err);
+            if (err) next(err);
             regions[i] = az.region;
-            this();
+            next();
         });
     }
     else {

--- a/index.js
+++ b/index.js
@@ -143,8 +143,8 @@ Step(function() {
     if (argv.filter && argv.filter.Swarm === '_self') {
         var next = this;
         Step(function() {
-            instanceMetadata.loadId(this.parrallel())
-            instanceMetadata.loadAz(this.parrallel());
+            instanceMetadata.loadId(this.parallel())
+            instanceMetadata.loadAz(this.parallel());
         },
         function(err, id, az) {
             if (err) throw (err);

--- a/index.js
+++ b/index.js
@@ -1,14 +1,12 @@
 #!/usr/bin/env node
 // A tool for working with swarms of MapBox servers.
 
-var aws = require('aws-lib');
 var Step = require('step');
 var _ = require('underscore');
 var fs = require('fs');
-var get = require('get');
 var yamlish = require('yamlish');
-var config;
-var clients = {};
+var instanceMetadata = require('./lib/instance-metadata');
+var ec2Api= require('./lib/ec2-api');
 
 var optimist = require('optimist')
     .usage('A tool for working with swarms of MapBox servers.\n' +
@@ -60,6 +58,8 @@ if (argv.config) {
     }
 }
 
+var regions = argv.regions.split(',');
+
 if (argv.awsKey) config.awsKey = argv.awsKey;
 if (argv.awsSecret) config.awsSecret= argv.awsSecret;
 
@@ -68,17 +68,13 @@ if (!config.awsKey || !config.awsSecret) {
     process.exit(1);
 }
 
-_(argv.regions.split(',')).each(function(region) {
-    clients[region] = aws.createEC2Client(config.awsKey, config.awsSecret, 
-      {version: '2012-03-01', host: 'ec2.' + region + '.amazonaws.com'});
-});
-
 var swarm = {};
 
 // List
 swarm.list = function() {
     Step(function() {
-        loadTags(this);
+        var filters = {'resource-type': 'instance'};
+        ec2Api.loadTags(ec2Api.createClients(config, regions), filters, this);
     }, function(err, tags) {
         if (err) throw err;
         var swarms = _(tags).chain()
@@ -91,7 +87,7 @@ swarm.list = function() {
 
 swarm.metadata = function() {
     Step(function() {
-        loadInstances(this);
+        ec2Api.loadInstances(ec2Api.createClients(config, regions), argv.filter, this);
     }, function(err, instances) {
         if (err) throw err;
         var possibleAttr = _(instances).chain()
@@ -128,7 +124,7 @@ swarm.metadata = function() {
 //
 swarm.classify = function() {
     Step(function() {
-        loadInstances(this);
+        ec2Api.loadInstances(ec2Api.createClients(config, regions), argv.filter, this);
     }, function(err, instances) {
         if (err) throw err;
         var instance = _(instances).first();
@@ -140,140 +136,47 @@ swarm.classify = function() {
     });
 };
 
-swarm[command]();
-
-function loadInstances(callback) {
-    var instances = [];
-    var i;
-    // Special filters
-    var exclude = ['Class', 'Parameter', 'Environment', 'ClassParameter'];
-    Step(function() {
-        var group = this.group();
-        _(clients).each(function(client) {
-            client.call('DescribeInstances', {}, group());
+// If any supported arguments have the `_self` value we resolve then first, and
+// then actually run the command.
+Step(function() {
+    // --filter.Swarm _self
+    if (argv.filter && argv.filter.Swarm === '_self') {
+        var next = this;
+        Step(function() {
+            instanceMetadata.loadId(this.parrallel())
+            instanceMetadata.loadAz(this.parrallel());
+        },
+        function(err, id, az) {
+            if (err) throw (err);
+            var filters = {'resource-type': 'instance', 'resource-id': id};
+            ec2Api.loadTags(ec2Api.createClients(config, [az.region]), filters, this);
+        },
+        function(err, tags) {
+            if (err) throw (err);
+            argv.filter.Swarm = _(tags).pluck('Swarm').compact().first().value();
+            next();
         });
-    },
-    function(err, result) {
-        if (err) throw err;
-        if (result.Errors) throw new Error(result.Errors.Error.Message);
-        _(result).chain()
-            .map(function(v, k, list) {
-                if (v.reservationSet.item) return v.reservationSet.item;
-            })
-            .compact()
-            .flatten()
-            .pluck('instancesSet')
-            .pluck('item')
-            .each(function(item) {
-                if (_.isArray(item)) {
-                    Array.prototype.push.apply(instances, item)
-                }
-                else {
-                    instances.push(item);
-                }
-            });
-
-        i = _(instances).chain()
-            .filter(function(instance) {
-                return instance.tagSet !== undefined;
-            })
-            .map(function(instance) {
-                _(instance.tagSet.item).each(function(tag) {
-                    instance[tag.key] = tag.value;
-                });
-                instance.State = instance.instanceState.name;
-                return instance;
-            })
-            .map(function(instance) {
-                var i = {};
-                _(instance).each(function(v, k) {
-                    if (_(v).isString()) {
-                        i[k] = v;
-                    }
-                });
-                return i;
-            });
-
-        if (argv.filter && argv.filter.Swarm === '_self') {
-            loadInstanceId(function(err, instanceId) {
-                if (err) throw err;
-                argv.filter.Swarm = i.filter(function(instance) {
-                    return instance.instanceId === instanceId;
-                }).pluck('Swarm').compact().first().value();
-                this();
-            }.bind(this));
-        } else {
+    }
+    else {
+        this();
+    }
+},
+function(err) {
+    if (err) throw err;
+    // --regions _self
+    var i = regions.indexOf('_self');
+    if (i !== -1) {
+        instanceMetadata.loadAz(function(err, az) {
+            if (err) this(err);
+            regions[i] = az.region;
             this();
-        }
-    },
-    function(err) {
-        if (err) throw err;
-        _(argv.filter).each(function(v, k) {
-            if (_.indexOf(exclude, k) == -1) {
-                i = i.filter(function(instance) {
-                    return _(instance[k]).isString() &&
-                        instance[k].toLowerCase() === v.toLowerCase();
-                });
-            } else {
-                // Handle special filters
-                i = i.filter(function(instance) {
-                    switch(k) {
-                        case 'Class':
-                            if (instance.PuppetClasses) {
-                                return _.has(JSON.parse(instance.PuppetClasses), argv.filter.Class);
-                            } else { return false }
-                        case 'Parameter':
-                            // These are global parameters, not class parameters
-                            if (instance.PuppetParameters) {
-                                return _.has(JSON.parse(instance.PuppetParameters), argv.filter.Parameter);
-                            } else { return false }
-                        case 'Environment':
-                            if (instance.PuppetEnvironment) {
-                                return instance.PuppetEnvironment;
-                            } else { return false }
-                        case 'ClassParameter':
-                            if (instance.PuppetClasses) {
-                                var klass = argv.filter.ClassParameter.split(':')[0];
-                                var param = argv.filter.ClassParameter.split(':')[1];
-                                if (_.has(JSON.parse(instance.PuppetClasses), klass)) {
-                                    return _.has(JSON.parse(instance.PuppetClasses)[klass], param)
-                                } else { return false; }
-                            } else { return false; }
-                        default:
-                            return false;
-                    }
-                });
-            }
         });
-        return callback(err, i.value());
-    });
-};
-
-function loadTags(callback) {
-    Step(function() {
-        var group = this.group();
-        _(clients).each(function(client) {
-            client.call('DescribeTags', {
-                'Filter.1.Name': 'resource-type',
-                'Filter.1.Value': 'instance'
-                }, group());
-        });
-    },
-    function(err, result) {
-        if (result.Errors) return callback(result.Errors.Error.Message);
-        callback(null, _(result).chain()
-            .map(function(v, k) {
-                if (v.tagSet) {
-                    return v.tagSet.item;
-                }
-            })
-            .flatten()
-            .compact()
-            .value()
-        );
-    });
-};
-
-function loadInstanceId(callback) {
-    (new get('http://169.254.169.254/latest/meta-data/instance-id')).asString(callback);
-}
+    }
+    else {
+        this();
+    }
+},
+function(err) {
+    if (err) throw err;
+    swarm[command]();
+});

--- a/lib/ec2-api.js
+++ b/lib/ec2-api.js
@@ -1,0 +1,136 @@
+// ec2 API calls.
+var aws = require('aws-lib');
+var Step = require('step');
+var _ = require('underscore');
+
+// Generates aws api clients for use by other methods.
+exports.createClients = function(config, regions) {
+    var clients = {};
+    _(regions).each(function(region) {
+        clients[region] = aws.createEC2Client(config.awsKey, config.awsSecret, 
+          {version: '2012-03-01', host: 'ec2.' + region + '.amazonaws.com'});
+    });
+    return clients;
+}
+
+// Loads instances and optionally filters them.
+exports.loadInstances = function(clients, filters, callback) {
+    Step(function() {
+        var group = this.group();
+        _(clients).each(function(client) {
+            client.call('DescribeInstances', {}, group());
+        });
+    },
+    function(err, result) {
+        if (err) throw err;
+
+        var instances = [];
+        _(result).chain()
+            .map(function(v, k, list) {
+                if (v.reservationSet.item) return v.reservationSet.item;
+            })
+            .compact()
+            .flatten()
+            .pluck('instancesSet')
+            .pluck('item')
+            .each(function(item) {
+                if (_.isArray(item)) {
+                    Array.prototype.push.apply(instances, item)
+                }
+                else {
+                    instances.push(item);
+                }
+            });
+
+        var i = _(instances).chain()
+            .filter(function(instance) {
+                return instance.tagSet !== undefined;
+            })
+            .map(function(instance) {
+                _(instance.tagSet.item).each(function(tag) {
+                    instance[tag.key] = tag.value;
+                });
+                instance.State = instance.instanceState.name;
+                return instance;
+            })
+            .map(function(instance) {
+                var i = {};
+                _(instance).each(function(v, k) {
+                    if (_(v).isString()) {
+                        i[k] = v;
+                    }
+                });
+                return i;
+            });
+
+        // Special filters
+        var exclude = ['Class', 'Parameter', 'Environment', 'ClassParameter'];
+
+        _(filters).each(function(v, k) {
+            if (_.indexOf(exclude, k) == -1) {
+                i = i.filter(function(instance) {
+                    return _(instance[k]).isString() &&
+                        instance[k].toLowerCase() === v.toLowerCase();
+                });
+            } else {
+                // Handle special filters
+                i = i.filter(function(instance) {
+                    switch(k) {
+                        case 'Class':
+                            if (instance.PuppetClasses) {
+                                return _.has(JSON.parse(instance.PuppetClasses), filters.Class);
+                            } else { return false }
+                        case 'Parameter':
+                            // These are global parameters, not class parameters
+                            if (instance.PuppetParameters) {
+                                return _.has(JSON.parse(instance.PuppetParameters), filters.Parameter);
+                            } else { return false }
+                        case 'Environment':
+                            if (instance.PuppetEnvironment) {
+                                return instance.PuppetEnvironment;
+                            } else { return false }
+                        case 'ClassParameter':
+                            if (instance.PuppetClasses) {
+                                var klass = filters.ClassParameter.split(':')[0];
+                                var param = filters.ClassParameter.split(':')[1];
+                                if (_.has(JSON.parse(instance.PuppetClasses), klass)) {
+                                    return _.has(JSON.parse(instance.PuppetClasses)[klass], param)
+                                } else { return false; }
+                            } else { return false; }
+                        default:
+                            return false;
+                    }
+                });
+            }
+        });
+
+        return callback(null, i.value());
+    });
+};
+
+exports.loadTags = function(clients, filters, callback) {
+    var i = 1;
+    var params = {};
+    _(filters).each(function(v, k) {
+        params['Filter.' + i + '.Name'] = k;
+        params['Filter.' + i + '.Value'] = v;
+        i++;
+    });
+    Step(function() {
+        var group = this.group();
+        _(clients).each(function(client) {
+            client.call('DescribeTags', _(params).clone(), group());
+        });
+    },
+    function(err, result) {
+        if (err) throw err;
+
+        var tags =  _(result).chain()
+            .map(function(v, k) { if (v.tagSet) return v.tagSet.item })
+            .flatten()
+            .compact()
+            .value()
+
+        callback(null, tags);
+    });
+};

--- a/lib/instance-metadata.js
+++ b/lib/instance-metadata.js
@@ -1,0 +1,25 @@
+// ec2 Instance meta-data api calls.
+var get = require('get');
+
+var cache = {};
+
+exports.loadId = function(callback) {
+    if (cache.id) return callback(null, cache.id);
+    (new get('http://169.254.169.254/latest/meta-data/instance-id'))
+        .asString(function(err, id) {
+            if (err) callback(err);
+            cache.id = id;
+            callback(null, cache.id);
+        });
+};
+
+exports.loadAz = function(callback) {
+    if (cache.az) return callback(null, cache.az);
+    (new get('http://169.254.169.254/latest/meta-data/placement/availability-zone'))
+        .asString(function(err, az) {
+            if (err) callback(err);
+            var match = /^(.+)([a-z]{1})$/.exec(az)
+            cache.az = {region: match[1], az: match[2]}
+            callback(null, cache.az);
+        });
+};


### PR DESCRIPTION
This work fixes the issue where you couldn't use `--filter.Swarm _self` for a region your ec2 was not in. This "fix" ended up being a bit of a refactor of the internals;
1. `_self` can now also be used with `--region` and happens before any command execution.
2. lookups agaisnt the instance metadata api are now in their own file in `/lib` and there is a new method for lookup up the region and az of the instance.
3. calls again the ec2 api are in a different file in `/lib` and have been reworked.

The upshot of 2 & 3 is that it's probably possible to use swarms libs as APIs themselves, which could be nice for things like colonize.

**THIS NEEDS MORE TESTING**
