### PR TITLE
Use instanceId as filter param in puppet classifier

### DIFF
--- a/puppet-classifier
+++ b/puppet-classifier
@@ -1,3 +1,3 @@
 #!/usr/bin/env bash
 
-/usr/bin/swarm classify --config /usr/local/etc/swarm/settings.json --filter.privateDnsName=`curl -s http://169.254.169.254/latest/meta-data/local-hostname`
+/usr/bin/swarm classify --config /usr/local/etc/swarm/settings.json --filter.instanceId=_self


### PR DESCRIPTION
Fixes an issue where the puppet classifier wouldn't get any results in VPC as the privateDnsName is dependent on your subnet.
